### PR TITLE
Custom system properties

### DIFF
--- a/app/src/main/java/javax/microedition/shell/ConfigActivity.java
+++ b/app/src/main/java/javax/microedition/shell/ConfigActivity.java
@@ -77,6 +77,7 @@ public class ConfigActivity extends AppCompatActivity implements View.OnClickLis
 	protected EditText tfFontSizeMedium;
 	protected EditText tfFontSizeLarge;
 	protected CheckBox cxFontSizeInSP;
+	protected EditText tfSystemProperties;
 	protected CheckBox cxShowKeyboard;
 
 	protected SeekBar sbVKAlpha;
@@ -161,6 +162,7 @@ public class ConfigActivity extends AppCompatActivity implements View.OnClickLis
 		tfFontSizeMedium = findViewById(R.id.tfFontSizeMedium);
 		tfFontSizeLarge = findViewById(R.id.tfFontSizeLarge);
 		cxFontSizeInSP = findViewById(R.id.cxFontSizeInSP);
+		tfSystemProperties = findViewById(R.id.tfSystemProperties);
 		cxShowKeyboard = findViewById(R.id.cxIsShowKeyboard);
 
 		sbVKAlpha = findViewById(R.id.sbVKAlpha);
@@ -321,6 +323,7 @@ public class ConfigActivity extends AppCompatActivity implements View.OnClickLis
 		tfFontSizeMedium.setText(Integer.toString(params.getInt("FontSizeMedium", 22)));
 		tfFontSizeLarge.setText(Integer.toString(params.getInt("FontSizeLarge", 26)));
 		cxFontSizeInSP.setChecked(params.getBoolean("FontApplyDimensions", false));
+		tfSystemProperties.setText(params.getString("SystemProperties"));
 		cxShowKeyboard.setChecked(params.getBoolean(("ShowKeyboard"), true));
 
 		sbVKAlpha.setProgress(params.getInt("VirtualKeyboardAlpha", 64));
@@ -358,6 +361,7 @@ public class ConfigActivity extends AppCompatActivity implements View.OnClickLis
 			params.putInt("FontSizeLarge",
 					Integer.parseInt(tfFontSizeLarge.getText().toString()));
 			params.putBoolean("FontApplyDimensions", cxFontSizeInSP.isChecked());
+			params.putString("SystemProperties", tfSystemProperties.getText().toString());
 			params.putBoolean("ShowKeyboard", cxShowKeyboard.isChecked());
 
 			params.putInt("VirtualKeyboardAlpha", sbVKAlpha.getProgress());
@@ -402,6 +406,14 @@ public class ConfigActivity extends AppCompatActivity implements View.OnClickLis
 			Font.setSize(Font.SIZE_MEDIUM, fontSizeMedium);
 			Font.setSize(Font.SIZE_LARGE, fontSizeLarge);
 			Font.setApplyDimensions(fontApplyDimensions);
+
+			final String[] propLines = tfSystemProperties.getText().toString().split("\n");
+			for (String line : propLines) {
+				String[] prop = line.split(":", 2);
+				if (prop.length == 2) {
+					System.setProperty(prop[0], prop[1]);
+				}
+			}
 
 			Canvas.setVirtualSize(screenWidth, screenHeight, screenScaleToFit,
 					screenKeepAspectRatio, screenScaleRatio);

--- a/app/src/main/res/layout/config_all.xml
+++ b/app/src/main/res/layout/config_all.xml
@@ -222,6 +222,21 @@
             android:text="@string/PREF_LANGUAGE" />
 
         <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="5dp"
+            android:text="@string/PREF_SYS_PROPS"
+            android:textAppearance="?android:attr/textAppearanceLarge" />
+
+        <EditText
+            android:id="@+id/tfSystemProperties"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/PREF_SYS_PROPS_HINT"
+            android:inputType="textMultiLine"
+            android:lines="2"/>
+
+        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="5dp"

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -56,6 +56,7 @@
   <string name="SIZE_PRESETS">Предустановки</string>
   <string name="PREF_LANGUAGE">Язык: %1$s</string>
   <string name="PREF_MISC">Прочие параметры</string>
+  <string name="PREF_SYS_PROPS">Системные параметры</string>
   <string name="PREF_VK_SHOW">Показывать клавиатуру</string>
   <string name="PREF_IMMEDIATE">Режим неотложной обработки</string>
   <string name="SWAP_SIZES">Поменять местами</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -54,6 +54,7 @@
   <string name="SIZE_PRESETS">Шаблони</string>
   <string name="PREF_LANGUAGE">Мова: %1$s</string>
   <string name="PREF_MISC">Додаткові опції</string>
+  <string name="PREF_SYS_PROPS">Системні опції</string>
   <string name="PREF_VK_SHOW">Показати клавіатуру</string>
   <string name="PREF_IMMEDIATE">Режим невідкладної обробки</string>
   <string name="SWAP_SIZES">Поміняти розміри</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,8 @@
     <string name="SIZE_PRESETS">Presets</string>
     <string name="PREF_LANGUAGE" formatted="false">Language: %1$s</string>
     <string name="PREF_MISC">Misc options</string>
+    <string name="PREF_SYS_PROPS">System properties</string>
+    <string name="PREF_SYS_PROPS_HINT" translatable="false">microedition.platform: Sony Ericsson C510i\nmicroedition.profiles: MIDP2.0</string>
     <string name="PREF_VK_SHOW">Show keyboard</string>
     <string name="PREF_IMMEDIATE">Immediate processing mode</string>
     <string name="SWAP_SIZES">Swap sizes</string>


### PR DESCRIPTION
Some applications rely on system properties and perform some optimizations based on device manufacturer or model, e.g. reduce particles count for Nokia and Samsung devices or enable visual effects for Sony Ericsson. This pull request adds an ability to set new system properties or overwrite [default properties](https://github.com/nikita36078/J2ME-Loader/blob/1fb9b5bdc65ddd2eaabb2a76bbff284cd5eed8b3/app/src/main/java/javax/microedition/shell/ConfigActivity.java#L134-L147).