### PR TITLE
Added QWERTY keyboard feature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,6 +81,7 @@ android {
             path 'src/main/cpp/Android.mk'
         }
     }
+    ndkVersion '22.1.7171670'
 }
 
 static def generateVersionCode() {

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <application tools:ignore="GoogleAppIndexingWarning">
         <activity
             android:name="javax.microedition.shell.MicroActivity"
+            android:windowSoftInputMode="adjustResize"
             tools:remove="android:process"/>
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -80,6 +80,7 @@
             android:windowSoftInputMode="stateHidden" />
         <activity
             android:name="javax.microedition.shell.MicroActivity"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/AppTheme.NoActionBar"
             android:process=":midlet"
             android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize" />

--- a/app/src/main/java/javax/microedition/lcdui/keyboard/KeyMapper.java
+++ b/app/src/main/java/javax/microedition/lcdui/keyboard/KeyMapper.java
@@ -53,7 +53,8 @@ public class KeyMapper {
 	private static final SparseIntArray keyCodeToCustom = new SparseIntArray();
 	private static final SparseIntArray keyCodeToGameAction = new SparseIntArray();
 	private static final SparseIntArray gameActionToKeyCode = new SparseIntArray();
-	private static SparseIntArray androidToMIDP;
+	private static SparseIntArray androidToMIDP = new SparseIntArray();
+	private static SparseIntArray SymToMIDP = new SparseIntArray(), CommToMIDP = new SparseIntArray();
 	private static int layoutType;
 
 	static {
@@ -89,6 +90,40 @@ public class KeyMapper {
 		mapGameAction(GAME_B, KEY_NUM9);
 		mapGameAction(GAME_C, KEY_STAR);
 		mapGameAction(GAME_D, KEY_POUND);
+
+		SymToMIDP.put(KeyEvent.KEYCODE_SPACE, 32); //Space
+		SymToMIDP.put(8, 33); //!
+		SymToMIDP.put(75, 34); //"
+		SymToMIDP.put(KeyEvent.KEYCODE_POUND, 35); //#
+		SymToMIDP.put(11, 36); //$
+		SymToMIDP.put(12, 37); //%
+		SymToMIDP.put(14, 38); //&
+		SymToMIDP.put(KeyEvent.KEYCODE_APOSTROPHE, 39); //'
+		SymToMIDP.put(16, 40); //(
+		SymToMIDP.put(7, 41); //)
+		SymToMIDP.put(KeyEvent.KEYCODE_STAR, 42); //*
+		SymToMIDP.put(KeyEvent.KEYCODE_NUMPAD_ADD, 43); //+
+		SymToMIDP.put(KeyEvent.KEYCODE_COMMA, 44); //,
+		SymToMIDP.put(KeyEvent.KEYCODE_MINUS, 45); //-
+		SymToMIDP.put(KeyEvent.KEYCODE_PERIOD, 46); //.
+		SymToMIDP.put(KeyEvent.KEYCODE_SLASH, 47); // /
+		SymToMIDP.put(74, 58); //:
+		SymToMIDP.put(KeyEvent.KEYCODE_SEMICOLON, 59);//;
+		SymToMIDP.put(55, 60); //<
+		SymToMIDP.put(KeyEvent.KEYCODE_EQUALS, 61); //=
+		SymToMIDP.put(56, 62); //>
+		SymToMIDP.put(76, 63); //?
+		SymToMIDP.put(KeyEvent.KEYCODE_AT, 64); //@
+		//SymToMIDP.put(68, 126); //~ Disabled, same code as grave (`)
+		SymToMIDP.put(KeyEvent.KEYCODE_LEFT_BRACKET, 91); //[
+		SymToMIDP.put(KeyEvent.KEYCODE_BACKSLASH, 92); //\
+		SymToMIDP.put(KeyEvent.KEYCODE_RIGHT_BRACKET, 93); //]
+		SymToMIDP.put(13, 94);//^
+		SymToMIDP.put(69, 95);//_
+		SymToMIDP.put(KeyEvent.KEYCODE_GRAVE, 96); //`
+
+		CommToMIDP.put(KeyEvent.KEYCODE_DEL, -8/*127*//*8*/); //Backspace
+
 	}
 
 	private static void remapKeys() {
@@ -156,6 +191,14 @@ public class KeyMapper {
 		return keyCodeToCustom.get(keyCode, keyCode);
 	}
 
+	public static int SymToMIDP(int code){
+		return SymToMIDP.get(code, Integer.MAX_VALUE);
+	}
+
+	public static int CommToMIDP(int code){
+		return CommToMIDP.get(code, Integer.MAX_VALUE);
+	}
+
 	public static void setKeyMapping(ProfileModel params) {
 		layoutType = params.keyCodesLayout;
 		androidToMIDP = params.keyMappings;
@@ -174,7 +217,9 @@ public class KeyMapper {
 	}
 
 	public static String getKeyName(int keyCode) {
-		return keyCodeToKeyName.get(keyCode);
+		String value = keyCodeToKeyName.get(keyCode, null);;
+		if(value == null) return String.valueOf((char)keyCode);
+		return value;
 	}
 
 	public static SparseIntArray getDefaultKeyMap() {

--- a/app/src/main/java/javax/microedition/lcdui/keyboard/VirtualKeyboard.java
+++ b/app/src/main/java/javax/microedition/lcdui/keyboard/VirtualKeyboard.java
@@ -908,9 +908,9 @@ public class VirtualKeyboard implements Overlay, Runnable {
 						vibrate();
 						associatedKeys[pointer] = aKeypad;
 						aKeypad.selected = true;
-						target.postKeyPressed(aKeypad.keyCode);
+						target.postKeyPressed(KeyMapper.convertKeyCode(aKeypad.keyCode));
 						if (aKeypad.secondKeyCode != 0) {
-							target.postKeyPressed(aKeypad.secondKeyCode);
+							target.postKeyPressed(KeyMapper.convertKeyCode(aKeypad.secondKeyCode));
 						}
 						handler.postDelayed(aKeypad, 400);
 						overlayView.postInvalidate();
@@ -966,10 +966,10 @@ public class VirtualKeyboard implements Overlay, Runnable {
 				} else if (!aKey.contains(x, y)) {
 					associatedKeys[pointer] = null;
 					handler.removeCallbacks(aKey);
-					target.postKeyReleased(aKey.keyCode);
+					target.postKeyReleased(KeyMapper.convertKeyCode(aKey.keyCode));
 					int secondKeyCode = aKey.secondKeyCode;
 					if (secondKeyCode != 0) {
-						target.postKeyReleased(secondKeyCode);
+						target.postKeyReleased(KeyMapper.convertKeyCode(secondKeyCode));
 					}
 					aKey.selected = false;
 					overlayView.postInvalidate();
@@ -1041,10 +1041,10 @@ public class VirtualKeyboard implements Overlay, Runnable {
 			if (key != null) {
 				associatedKeys[pointer] = null;
 				handler.removeCallbacks(key);
-				target.postKeyReleased(key.keyCode);
+				target.postKeyReleased(KeyMapper.convertKeyCode(key.keyCode));
 				int secondKeyCode = key.secondKeyCode;
 				if (secondKeyCode != 0) {
-					target.postKeyReleased(secondKeyCode);
+					target.postKeyReleased(KeyMapper.convertKeyCode(secondKeyCode));
 				}
 				key.selected = false;
 				overlayView.postInvalidate();
@@ -1276,9 +1276,9 @@ public class VirtualKeyboard implements Overlay, Runnable {
 				return;
 			}
 			if (selected) {
-				target.postKeyRepeated(keyCode);
+				target.postKeyRepeated(KeyMapper.convertKeyCode(keyCode));
 				if (secondKeyCode != 0) {
-					target.postKeyRepeated(secondKeyCode);
+					target.postKeyRepeated(KeyMapper.convertKeyCode(secondKeyCode));
 				}
 				handler.postDelayed(this, repeatCount > 6 ? 80 : REPEAT_INTERVALS[repeatCount++]);
 			} else {

--- a/app/src/main/java/javax/microedition/shell/MicroActivity.java
+++ b/app/src/main/java/javax/microedition/shell/MicroActivity.java
@@ -18,6 +18,7 @@
 package javax.microedition.shell;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -38,6 +39,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView.AdapterContextMenuInfo;
 import android.widget.EditText;
 import android.widget.FrameLayout;
@@ -92,9 +94,11 @@ public class MicroActivity extends AppCompatActivity {
 	private Toolbar toolbar;
 	private MicroLoader microLoader;
 	private String appName;
+	private InputMethodManager keyboard;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
+		keyboard = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
 		SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
 		setTheme(sp.getString(PREF_THEME, "light"));
 		super.onCreate(savedInstanceState);
@@ -141,6 +145,7 @@ public class MicroActivity extends AppCompatActivity {
 			e.printStackTrace();
 			showErrorDialog(e.toString());
 		}
+
 	}
 
 	@Override
@@ -343,6 +348,7 @@ public class MicroActivity extends AppCompatActivity {
 
 	@Override
 	public boolean onKeyUp(int keyCode, KeyEvent event) {
+
 		if ((keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_MENU) && !keyLongPressed) {
 			openOptionsMenu();
 			return true;
@@ -400,6 +406,8 @@ public class MicroActivity extends AppCompatActivity {
 				showExitConfirmation();
 			} else if (id == R.id.action_take_screenshot) {
 				takeScreenshot();
+			}else if(id == R.id.action_show_QWERTY){
+				showQWERTYKeyboard();
 			} else if (id == R.id.action_save_log) {
 				saveLog();
 			} else if (id == R.id.action_limit_fps){
@@ -461,6 +469,27 @@ public class MicroActivity extends AppCompatActivity {
 						Toast.makeText(MicroActivity.this, R.string.error, Toast.LENGTH_SHORT).show();
 					}
 				});
+	}
+
+	//@TODO Fix the bug that makes the keyboard don't work anymore after closing a MIDlet and openning another, until J2ME Loader is minimized and remaximized
+	private void showQWERTYKeyboard(){
+
+		if (current == null || !(current instanceof Canvas)) {
+			return;
+		}
+
+		Canvas canvas = (Canvas) current;
+		current.getDisplayableView(); //Makes sure there's a displayable view
+		View view = ContextHolder.getActivity().getCurrentFocus();//canvas.getInnerView();
+		view.requestFocus();
+
+		keyboard.showSoftInput(view, InputMethodManager.SHOW_FORCED);
+		//keyboard.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
+	}
+
+	private void hideQWERTYKeyboard(){
+		View view = ContextHolder.getActivity().getCurrentFocus();
+		keyboard.hideSoftInputFromWindow(view.getWindowToken(), 0);
 	}
 
 	private void saveLog() {

--- a/app/src/main/java/javax/microedition/shell/MidletThread.java
+++ b/app/src/main/java/javax/microedition/shell/MidletThread.java
@@ -24,6 +24,7 @@ import android.util.Log;
 
 import javax.microedition.lcdui.Canvas;
 import javax.microedition.lcdui.Displayable;
+import javax.microedition.lcdui.keyboard.KeyMapper;
 import javax.microedition.midlet.MIDlet;
 import javax.microedition.midlet.MIDletStateChangeException;
 import javax.microedition.util.ContextHolder;
@@ -103,8 +104,8 @@ public class MidletThread extends HandlerThread implements Handler.Callback {
 			Displayable current = activity.getCurrent();
 			if (current instanceof Canvas) {
 				Canvas canvas = (Canvas) current;
-				canvas.postKeyPressed(Canvas.KEY_END);
-				canvas.postKeyReleased(Canvas.KEY_END);
+				canvas.postKeyPressed(KeyMapper.convertKeyCode(Canvas.KEY_END));
+				canvas.postKeyReleased(KeyMapper.convertKeyCode(Canvas.KEY_END));
 			}
 		}
 		if (instance != null) {

--- a/app/src/main/res/drawable/ic_baseline_keyboard_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_keyboard_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M20,5L4,5c-1.1,0 -1.99,0.9 -1.99,2L2,17c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,7c0,-1.1 -0.9,-2 -2,-2zM11,8h2v2h-2L11,8zM11,11h2v2h-2v-2zM8,8h2v2L8,10L8,8zM8,11h2v2L8,13v-2zM7,13L5,13v-2h2v2zM7,10L5,10L5,8h2v2zM16,17L8,17v-2h8v2zM16,13h-2v-2h2v2zM16,10h-2L14,8h2v2zM19,13h-2v-2h2v2zM19,10h-2L17,8h2v2z"/>
+</vector>

--- a/app/src/main/res/menu/midlet_canvas.xml
+++ b/app/src/main/res/menu/midlet_canvas.xml
@@ -8,6 +8,12 @@
             app:showAsAction="always"/>
 
         <item
+            android:icon="@drawable/ic_baseline_keyboard_24"
+            android:id="@+id/action_show_QWERTY"
+            android:title="@string/show_qwerty"
+            app:showAsAction="always"/>
+
+        <item
             android:id="@+id/action_limit_fps"
             android:title="@string/PREF_LIMIT_FPS"
             />

--- a/app/src/main/res/menu/midlet_canvas_no_bar.xml
+++ b/app/src/main/res/menu/midlet_canvas_no_bar.xml
@@ -5,6 +5,10 @@
             android:title="@string/take_screenshot" />
 
         <item
+            android:id="@+id/action_show_QWERTY"
+            android:title="@string/show_qwerty" />
+
+        <item
             android:id="@+id/action_limit_fps"
             android:title="@string/PREF_LIMIT_FPS"
             />

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -100,6 +100,7 @@
     <string name="layout_switch">Смяна на подредбата</string>
     <string name="hide_buttons">Скриване на бутони</string>
     <string name="take_screenshot">Снимане на екрана</string>
+    <string name="show_qwerty">Показване на QWERTY клавиатура</string>
     <string name="screenshot_saved">Снимката на екрана беше записана във</string>
     <string name="log_saved">Регистрационния файл е записан</string>
     <string name="common_settings">[ОБЩИ НАСТРОЙКИ]</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -92,6 +92,7 @@
     <string name="layout_switch">সুইচ keylayout</string>
     <string name="hide_buttons">বাটন আড়াল করুন</string>
     <string name="take_screenshot">স্ক্রীনশট নিন</string>
+    <string name="show_qwerty">QWERTY কীবোর্ড দেখান </string>
     <string name="screenshot_saved">স্ক্রিনসর্ট সংরক্ষণ করা হয়েছে</string>
     <string name="log_saved">লগ সংরক্ষণ করা হয়েছে</string>
     <string name="common_settings">[সাধারণ সেটিংস]</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -93,6 +93,7 @@
     <string name="layout_switch">Přepnout rozložení kláves</string>
     <string name="hide_buttons">Skrýt tlačítka</string>
     <string name="take_screenshot">Pořídit snímek obrazovky</string>
+    <string name="show_qwerty">Zobrazit QWERTY klávesnici</string>
     <string name="screenshot_saved">Snímek obrazovky byl uložen do</string>
     <string name="log_saved">Soubor log byl uložen</string>
     <string name="common_settings">[SPOLEČNÁ NASTAVENÍ]</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -83,4 +83,5 @@
     <string name="mapping_dialog_title">Tryk på en tast</string>
     <string name="mapping_dialog_message" formatted="false">Nuværende tastekonfiguration: %1$s</string>
     <string name="reset_mapping">Nulstil</string>
+    <string name="show_qwerty">Vis QWERTY-tastatur</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -91,6 +91,7 @@
     <string name="layout_switch">Tastaturlayout wechseln</string>
     <string name="hide_buttons">Tasten ausblenden</string>
     <string name="take_screenshot">Screenshot aufnehmen</string>
+    <string name="show_qwerty">QWERTZ-Tastatur anzeigen</string>
     <string name="screenshot_saved">Screenshot wurde gespeichert in</string>
     <string name="log_saved">Protokoll wurde gespeichert</string>
     <string name="common_settings">[ALLGEMEINE EINSTELLUNGEN]</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -101,6 +101,7 @@
     <string name="layout_switch">Cambiar disposición del teclado</string>
     <string name="hide_buttons">Ocultar botones</string>
     <string name="take_screenshot">Tomar captura de pantalla</string>
+    <string name="show_qwerty">Abrir teclado QWERTY</string>
     <string name="screenshot_saved">La captura de pantalla se ha guardado en</string>
     <string name="log_saved">El registro ha sido guardado</string>
     <string name="common_settings">[CONFIGURACIÓN BÁSICA]</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -81,4 +81,5 @@
     <string name="pref_app_sort_title">Sovellusten lajittelujärjestys</string>
     <string name="pref_app_sort_name">Nimi</string>
     <string name="pref_app_sort_date">Päivämäärä</string>
+    <string name="show_qwerty">Näytä QWERTY-näppäimistö</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -99,6 +99,7 @@
     <string name="layout_switch">Changement de l\'affichage du clavier</string>
     <string name="hide_buttons">Masquer les boutons</string>
     <string name="take_screenshot">Prendre une capture d\'écran</string>
+    <string name="show_qwerty">Afficher le clavier QWERTY</string>
     <string name="screenshot_saved">La capture d\'écran a été enregistrée dans</string>
     <string name="log_saved">Logs a été sauvegardé</string>
     <string name="common_settings">[PARAMÈTRES COMMUNS]</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -101,6 +101,7 @@
     <string name="layout_switch">स्विच कीलेआउट</string>
     <string name="hide_buttons">बटन छिपाएं</string>
     <string name="take_screenshot">स्क्रीनशॉट लें</string>
+    <string name="show_qwerty">QWERTY कीबोर्ड दिखाएं</string>
     <string name="screenshot_saved">स्क्रीनशॉट को सहेज लिया गया है</string>
     <string name="log_saved">लॉग सहेजा गया है</string>
     <string name="common_settings">[सामान्य सेटिंग]</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -101,6 +101,7 @@
     <string name="layout_switch">Elrendezés váltása</string>
     <string name="hide_buttons">Gombok elrejtése</string>
     <string name="take_screenshot">Képernyőmentés készítése</string>
+    <string name="show_qwerty">QWERTY billentyűzet megjelenítése</string>
     <string name="screenshot_saved">A kép mentési helye:</string>
     <string name="log_saved">A naplófájl mentésre került</string>
     <string name="common_settings">[ÁLTALÁNOS BEÁLLÍTÁSOK]</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -101,6 +101,7 @@
     <string name="layout_switch">Tukar letak tombol</string>
     <string name="hide_buttons">Tombol yang tersembunyi</string>
     <string name="take_screenshot">Ambil screenshot</string>
+    <string name="show_qwerty">Tampilkan papan ketik QWERTY</string>
     <string name="screenshot_saved">Screenshot telah tersimpan ke</string>
     <string name="log_saved">Log telah disimpan</string>
     <string name="common_settings">[PENGATURAN UMUM]</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -101,6 +101,7 @@
     <string name="layout_switch">Cambia disposizione tasti</string>
     <string name="hide_buttons">Nascondi tasti</string>
     <string name="take_screenshot">Cattura schermata</string>
+    <string name="show_qwerty">Mostra tastiera QWERTY</string>
     <string name="screenshot_saved">La schermata è stata salvata in</string>
     <string name="log_saved">Il log è stato salvato</string>
     <string name="common_settings">[IMPOSTAZIONI COMUNI]</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -115,6 +115,7 @@
     <string name="layout_switch">버튼 배치를 맞바꾸다</string>
     <string name="hide_buttons">숨김 버튼</string>
     <string name="take_screenshot">스크린 캡처</string>
+    <string name="show_qwerty">QWERTY 키보드 표시</string>
     <string name="screenshot_saved">스크린샷이 저장되었습니다</string>
     <string name="log_saved">Log 저장됨</string>
     <string name="common_settings">[상용 설정]</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -101,6 +101,7 @@
     <string name="layout_switch">Wissel keylayout</string>
     <string name="hide_buttons">Verberg knoppen</string>
     <string name="take_screenshot">Maak schermafbeelding</string>
+    <string name="show_qwerty">QWERTY-toetsenbord weergeven</string>
     <string name="screenshot_saved">Schermafbeelding is opgeslagen in</string>
     <string name="log_saved">Logboek is opgeslagen</string>
     <string name="common_settings">[ALGEMENE INSTELLINGEN]</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -94,6 +94,7 @@
     <string name="layout_switch">Zmień układ przycisków</string>
     <string name="hide_buttons">Ukryj przyciski</string>
     <string name="take_screenshot">Zrób zrzut ekranu</string>
+    <string name="show_qwerty">Pokaż klawiaturę QWERTY</string>
     <string name="screenshot_saved">Zrzut ekranu został zapisany w</string>
     <string name="log_saved">Log został zapisany</string>
     <string name="common_settings">[WSPÓLNE USTAWIENIA]</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -101,6 +101,7 @@
     <string name="layout_switch">Alterar layout dos botões</string>
     <string name="hide_buttons">Ocultar botões</string>
     <string name="take_screenshot">Tirar captura de tela</string>
+    <string name="show_qwerty">Exibir teclado QWERTY</string>
     <string name="screenshot_saved">Captura de tela salva em</string>
     <string name="log_saved">Log foi salvo</string>
     <string name="common_settings">[CONFIGURAÇÕES COMUNS]</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -101,6 +101,7 @@
     <string name="layout_switch">Alternar Layout</string>
     <string name="hide_buttons">Esconder botões</string>
     <string name="take_screenshot">Capturar ecrã</string>
+    <string name="show_qwerty">Mostrar teclado QWERTY</string>
     <string name="screenshot_saved">Captura de ecrã foi salva em</string>
     <string name="log_saved">O registro foi salvo</string>
     <string name="common_settings">[CONFIGURAÇÕES COMUNS]</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -93,6 +93,7 @@
     <string name="layout_switch">Schimbă formatul tastaturii</string>
     <string name="hide_buttons">Ascunde butoanele</string>
     <string name="take_screenshot">Creează o captură de ecran</string>
+    <string name="show_qwerty">Afișați tastatura QWERTY</string>
     <string name="screenshot_saved">Captura de ecran a fost salvată în</string>
     <string name="log_saved">Jurnalul a fost salvat</string>
     <string name="common_settings">[SETĂRI COMUNE]</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -101,6 +101,7 @@
     <string name="layout_switch">Сменить раскладку</string>
     <string name="hide_buttons">Скрыть кнопки</string>
     <string name="take_screenshot">Сделать скриншот</string>
+    <string name="show_qwerty">Показать QWERTY клавиатуру</string>
     <string name="screenshot_saved">Скриншот сохранён в</string>
     <string name="log_saved">Лог сохранен</string>
     <string name="common_settings">[ОБЩИЕ НАСТРОЙКИ]</string>

--- a/app/src/main/res/values-sat/strings.xml
+++ b/app/src/main/res/values-sat/strings.xml
@@ -101,6 +101,7 @@
     <string name="layout_switch">ᱠᱤᱭᱞᱮᱭᱟᱩᱴ ᱥᱣᱤᱪ</string>
     <string name="hide_buttons">ᱵᱩᱛᱟᱹᱢᱠᱚ ᱩᱠᱩᱭ ᱢᱮ</string>
     <string name="take_screenshot">ᱥᱠᱨᱤᱱᱥᱚᱴ ᱤᱫᱤ ᱢᱮ</string>
+    <string name="show_qwerty">Show QWERTY keyboard</string>
     <string name="screenshot_saved">ᱥᱠᱨᱤᱱᱥᱚᱴ ᱫᱚ ᱥᱟᱸᱪᱟᱣ ᱮᱱᱟ</string>
     <string name="log_saved">ᱞᱚᱜ ᱫᱚ ᱥᱟᱸᱪᱟᱣ ᱮᱱᱟ</string>
     <string name="common_settings">[ᱠᱚᱢᱚᱱ ᱥᱟᱡᱟᱣ ᱠᱚ]</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -101,6 +101,7 @@
     <string name="layout_switch">Tuş düzenini değiştir</string>
     <string name="hide_buttons">Tuşları gizle</string>
     <string name="take_screenshot">Ekran görüntüsü al</string>
+    <string name="show_qwerty">QWERTY klavyeyi göster</string>
     <string name="screenshot_saved">Ekran görüntüsü şuraya kaydedildi</string>
     <string name="log_saved">Günlük kaydedildi</string>
     <string name="common_settings">[GENEL AYARLAR]</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -101,6 +101,7 @@
     <string name="layout_switch">Переключення розкладки клавіатури</string>
     <string name="hide_buttons">Приховати клавіші</string>
     <string name="take_screenshot">Зробити скріншот</string>
+    <string name="show_qwerty">Показати клавіатуру QWERTY</string>
     <string name="screenshot_saved">Скріншот було збережено до</string>
     <string name="log_saved">Журнал помилок збережено</string>
     <string name="common_settings">[ЗАГАЛЬНІ НАЛАШТУВАННЯ]</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -101,6 +101,7 @@
     <string name="layout_switch">Công tắc cấu trúc phím</string>
     <string name="hide_buttons">Ẩn nút</string>
     <string name="take_screenshot">Chụp ảnh màn hình</string>
+    <string name="show_qwerty">SHiển thị bàn phím QWERTY</string>
     <string name="screenshot_saved">Ảnh chụp màn hình đã được lưu đến</string>
     <string name="log_saved">Log đã được lưu</string>
     <string name="common_settings">[THIẾT LẬP CHUNG]</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -101,6 +101,7 @@
     <string name="layout_switch">切换按键布局</string>
     <string name="hide_buttons">隐藏按键</string>
     <string name="take_screenshot">屏幕截图</string>
+    <string name="show_qwerty">显示 QWERTY 键盘</string>
     <string name="screenshot_saved">屏幕截图已保存到</string>
     <string name="log_saved">日志已保存</string>
     <string name="common_settings">常用设置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@
     <string name="layout_switch">Switch keylayout</string>
     <string name="hide_buttons">Hide buttons</string>
     <string name="take_screenshot">Take screenshot</string>
+    <string name="show_qwerty">Show QWERTY keyboard</string>
     <string name="screenshot_saved">Screenshot has been saved to</string>
     <string name="log_saved">Log has been saved</string>
     <string name="common_settings">[COMMON SETTINGS]</string>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
Now users can display native Android soft keyboard and/or use a hardware one to write strings into MIDlets like in a usual QWERTY feature phone

Tested on LG K11+ (Android 7.1.2) and on Samsung SM-T116BU (Custom LineageOS ROM Android 7.1.2). They both are working fine, but with the same known bugs

Known bugs:

After closing a MIDlet and opening another without closing J2ME Loader, the soft keyboard stops sending input to the MIDlet, but returns to send input after minimizing and resuming the application. I'm not sure why this happens, but the MIDlet View are still focused, selected and active according to InputMethodManager. Tried many ways to fix it, but i couldn't