### PR TITLE
Add microedition.location.version prop

### DIFF
--- a/app/src/main/assets/defaults/system.props
+++ b/app/src/main/assets/defaults/system.props
@@ -7,6 +7,7 @@ microedition.sensor.version: 1
 microedition.m3g.version: 1.1
 microedition.media.version: 1.0
 microedition.pim.version: 1.0
+microedition.location.version: 1.0
 supports.mixing: true
 supports.audio.capture: true
 supports.video.capture: true


### PR DESCRIPTION
Needed for geolocation in Google Maps 3.0.2 to work.
Source: http://people.csail.mit.edu/rudolph/Teaching/Articles/Proximity/javax/microedition/location/package-summary.html