### PR TITLE
Synchronize Display.setCurrent()

### DIFF
--- a/app/src/main/java/javax/microedition/lcdui/Display.java
+++ b/app/src/main/java/javax/microedition/lcdui/Display.java
@@ -142,6 +142,12 @@ public class Display {
 
 	private void showCurrent() {
 		ContextHolder.getActivity().setCurrent(current);
+		try {
+			synchronized (this) {
+				wait();
+			}
+		} catch (InterruptedException e) {
+		}
 	}
 
 	public Displayable getCurrent() {

--- a/app/src/main/java/javax/microedition/lcdui/Display.java
+++ b/app/src/main/java/javax/microedition/lcdui/Display.java
@@ -142,12 +142,6 @@ public class Display {
 
 	private void showCurrent() {
 		ContextHolder.getActivity().setCurrent(current);
-		try {
-			synchronized (this) {
-				wait();
-			}
-		} catch (InterruptedException e) {
-		}
 	}
 
 	public Displayable getCurrent() {

--- a/app/src/main/java/javax/microedition/shell/MicroActivity.java
+++ b/app/src/main/java/javax/microedition/shell/MicroActivity.java
@@ -68,7 +68,6 @@ import java.util.Objects;
 
 import javax.microedition.lcdui.Alert;
 import javax.microedition.lcdui.Canvas;
-import javax.microedition.lcdui.Display;
 import javax.microedition.lcdui.Displayable;
 import javax.microedition.lcdui.Form;
 import javax.microedition.lcdui.List;
@@ -104,6 +103,8 @@ public class MicroActivity extends AppCompatActivity {
 	private String appPath;
 
 	public ActivityMicroBinding binding;
+
+	private final Object setCurrentLock = new Object();
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -327,6 +328,12 @@ public class MicroActivity extends AppCompatActivity {
 	public void setCurrent(Displayable displayable) {
 		ViewHandler.postEvent(new SetCurrentEvent(current, displayable));
 		current = displayable;
+		try {
+			synchronized (setCurrentLock) {
+				setCurrentLock.wait();
+			}
+		} catch (Exception ignored) {
+		}
 	}
 
 	public Displayable getCurrent() {
@@ -695,9 +702,8 @@ public class MicroActivity extends AppCompatActivity {
 					binding.displayableContainer.addView(next.getDisplayableView());
 				}
 			} finally {
-				Display display = Display.getDisplay(null);
-				synchronized(display) {
-					display.notify();
+				synchronized(setCurrentLock) {
+					setCurrentLock.notify();
 				}
 			}
 		}

--- a/app/src/main/java/javax/microedition/shell/MicroActivity.java
+++ b/app/src/main/java/javax/microedition/shell/MicroActivity.java
@@ -68,6 +68,7 @@ import java.util.Objects;
 
 import javax.microedition.lcdui.Alert;
 import javax.microedition.lcdui.Canvas;
+import javax.microedition.lcdui.Display;
 import javax.microedition.lcdui.Displayable;
 import javax.microedition.lcdui.Form;
 import javax.microedition.lcdui.List;
@@ -657,40 +658,47 @@ public class MicroActivity extends AppCompatActivity {
 
 		@Override
 		public void process() {
-			closeOptionsMenu();
-			if (current != null) {
-				current.clearDisplayableView();
-			}
-			if (next instanceof Alert) {
-				return;
-			}
-			binding.displayableContainer.removeAllViews();
-			ActionBar actionBar = Objects.requireNonNull(getSupportActionBar());
-			LinearLayout.LayoutParams layoutParams = (LinearLayout.LayoutParams) binding.toolbar.getLayoutParams();
-			int toolbarHeight = 0;
-			if (next instanceof Canvas) {
-				hideSystemUI();
-				if (!actionBarEnabled) {
-					actionBar.hide();
+			try {
+				closeOptionsMenu();
+				if (current != null) {
+					current.clearDisplayableView();
+				}
+				if (next instanceof Alert) {
+					return;
+				}
+				binding.displayableContainer.removeAllViews();
+				ActionBar actionBar = Objects.requireNonNull(getSupportActionBar());
+				LinearLayout.LayoutParams layoutParams = (LinearLayout.LayoutParams) binding.toolbar.getLayoutParams();
+				int toolbarHeight = 0;
+				if (next instanceof Canvas) {
+					hideSystemUI();
+					if (!actionBarEnabled) {
+						actionBar.hide();
+					} else {
+						final String title = next.getTitle();
+						actionBar.setTitle(title == null ? appName : title);
+						toolbarHeight = (int) (getToolBarHeight() / 1.5);
+						layoutParams.height = toolbarHeight;
+					}
 				} else {
-					final String title = next.getTitle();
+					showSystemUI();
+					actionBar.show();
+					final String title = next != null ? next.getTitle() : null;
 					actionBar.setTitle(title == null ? appName : title);
-					toolbarHeight = (int) (getToolBarHeight() / 1.5);
+					toolbarHeight = getToolBarHeight();
 					layoutParams.height = toolbarHeight;
 				}
-			} else {
-				showSystemUI();
-				actionBar.show();
-				final String title = next != null ? next.getTitle() : null;
-				actionBar.setTitle(title == null ? appName : title);
-				toolbarHeight = getToolBarHeight();
-				layoutParams.height = toolbarHeight;
-			}
-			binding.overlayView.setLocation(0, toolbarHeight);
-			binding.toolbar.setLayoutParams(layoutParams);
-			invalidateOptionsMenu();
-			if (next != null) {
-				binding.displayableContainer.addView(next.getDisplayableView());
+				binding.overlayView.setLocation(0, toolbarHeight);
+				binding.toolbar.setLayoutParams(layoutParams);
+				invalidateOptionsMenu();
+				if (next != null) {
+					binding.displayableContainer.addView(next.getDisplayableView());
+				}
+			} finally {
+				Display display = Display.getDisplay(null);
+				synchronized(display) {
+					display.notify();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Make it wait until display really shown. Without it any editing of form contents near `Display.setCurrent` calls can cause NullPointerException because `clearDisplayableView()` is called
![image](https://github.com/nikita36078/J2ME-Loader/assets/43963888/ba573aa0-a628-447a-9f7e-7a5fdd495b8b)