### PR TITLE
Add system property for Nokia UI SoftNotification

### DIFF
--- a/app/src/main/assets/defaults/system.props
+++ b/app/src/main/assets/defaults/system.props
@@ -21,4 +21,5 @@ com.sonyericsson.imei: IMEI 00460101-501594-5-00
 com.nokia.mid.impl.isa.visual_radio_operator_id: 0
 com.nokia.mid.impl.isa.visual_radio_channel_freq: 0
 com.nokia.mid.ui.DirectGraphics.PIXEL_FORMAT: 565
+com.nokia.mid.ui.softnotification: true
 wireless.messaging.sms.smsc: +8613800010000


### PR DESCRIPTION
Added system property to indicate that the implementation supports Nokia UI SoftNotification API. According to [Nokia's API docs](https://nikita36078.github.io/J2ME_Docs/docs/nokiaapi2/com/nokia/mid/ui/SoftNotification.html):
> This API is an optional feature in Nokia UI API, and depending on the device capabilities there may be implementations that do not support soft notifications. The System.getProperty("com.nokia.mid.ui.softnotification") will return "true" if this feature is available in the device. 