### PR TITLE
Add edit and delete management for custom resolution presets

### DIFF
--- a/app/src/main/java/ru/playsoftware/j2meloader/config/ConfigActivity.java
+++ b/app/src/main/java/ru/playsoftware/j2meloader/config/ConfigActivity.java
@@ -71,6 +71,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.fragment.app.FragmentManager;
 import androidx.preference.PreferenceManager;
+import androidx.core.content.ContextCompat;
 import androidx.core.widget.TextViewCompat;
 
 import ru.playsoftware.j2meloader.R;
@@ -867,10 +868,8 @@ public class ConfigActivity extends BaseActivity implements View.OnClickListener
 	private void showPencilMenu(View anchor, String preset) {
 		PopupMenu popup = new PopupMenu(this, anchor);
 		Menu menu = popup.getMenu();
-		TypedValue tv = new TypedValue();
-		getTheme().resolveAttribute(android.R.attr.colorPrimary, tv, true);
 		SpannableString editLabel = new SpannableString(getString(R.string.edit));
-		editLabel.setSpan(new ForegroundColorSpan(tv.data), 0, editLabel.length(), 0);
+		editLabel.setSpan(new ForegroundColorSpan(ContextCompat.getColor(this, R.color.btn_bg_normal)), 0, editLabel.length(), 0);
 		menu.add(0, 0, 0, editLabel);
 		SpannableString deleteLabel = new SpannableString(getString(R.string.action_context_delete));
 		deleteLabel.setSpan(new ForegroundColorSpan(Color.RED), 0, deleteLabel.length(), 0);

--- a/app/src/main/java/ru/playsoftware/j2meloader/config/ConfigActivity.java
+++ b/app/src/main/java/ru/playsoftware/j2meloader/config/ConfigActivity.java
@@ -520,6 +520,16 @@ public class ConfigActivity extends BaseActivity implements View.OnClickListener
 			screenPresets.addAll(preset);
 			customPresets.addAll(preset);
 		}
+		sortPresets();
+		String prev = null;
+		for (Iterator<String> iterator = screenPresets.iterator(); iterator.hasNext(); ) {
+			String next = iterator.next();
+			if (next.equals(prev)) iterator.remove();
+			else prev = next;
+		}
+	}
+
+	private void sortPresets() {
 		Collections.sort(screenPresets, (o1, o2) -> {
 			int sep1 = o1.indexOf(" x ");
 			int sep2 = o2.indexOf(" x ");
@@ -531,12 +541,6 @@ public class ConfigActivity extends BaseActivity implements View.OnClickListener
 			if (r != 0) return r;
 			return Integer.decode(o1.substring(sep1 + 3)).compareTo(Integer.decode(o2.substring(sep2 + 3)));
 		});
-		String prev = null;
-		for (Iterator<String> iterator = screenPresets.iterator(); iterator.hasNext(); ) {
-			String next = iterator.next();
-			if (next.equals(prev)) iterator.remove();
-			else prev = next;
-		}
 	}
 
 	private void addFontSizePreset(String title, int small, int medium, int large) {
@@ -945,6 +949,7 @@ public class ConfigActivity extends BaseActivity implements View.OnClickListener
 		screenPresets.remove(oldPreset);
 		customPresets.add(newPreset);
 		screenPresets.add(newPreset);
+		sortPresets();
 		if (presetsAdapter != null) presetsAdapter.notifyDataSetChanged();
 	}
 
@@ -996,14 +1001,14 @@ public class ConfigActivity extends BaseActivity implements View.OnClickListener
 		}
 
 		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
-		Set<String> set = preferences.getStringSet("ResolutionsPreset", null);
-		if (set == null) {
-			set = new HashSet<>(1);
-		}
+		Set<String> saved = preferences.getStringSet("ResolutionsPreset", null);
+		Set<String> set = saved != null ? new HashSet<>(saved) : new HashSet<>(1);
 		if (set.add(preset)) {
 			preferences.edit().putStringSet("ResolutionsPreset", set).apply();
 			screenPresets.add(preset);
 			customPresets.add(preset);
+			sortPresets();
+			if (presetsAdapter != null) presetsAdapter.notifyDataSetChanged();
 			Toast.makeText(this, R.string.saved, Toast.LENGTH_SHORT).show();
 		} else {
 			Toast.makeText(this, R.string.not_saved_exists, Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/ru/playsoftware/j2meloader/config/ConfigActivity.java
+++ b/app/src/main/java/ru/playsoftware/j2meloader/config/ConfigActivity.java
@@ -29,20 +29,28 @@ import android.os.storage.StorageManager;
 import android.os.storage.StorageVolume;
 import android.text.Editable;
 import android.text.InputFilter;
+import android.text.InputType;
+import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.TextWatcher;
+import android.text.style.ForegroundColorSpan;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.Display;
+import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.CompoundButton;
 import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.ListView;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import java.io.File;
@@ -58,6 +66,7 @@ import javax.microedition.shell.MicroActivity;
 import javax.microedition.util.ContextHolder;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.fragment.app.FragmentManager;
@@ -78,6 +87,9 @@ public class ConfigActivity extends BaseActivity implements View.OnClickListener
 	private static final String TAG = ConfigActivity.class.getSimpleName();
 
 	protected ArrayList<String> screenPresets = new ArrayList<>();
+	protected Set<String> customPresets = new HashSet<>();
+	private AlertDialog presetsDialog;
+	private ResolutionAdapter presetsAdapter;
 
 	protected ArrayList<int[]> fontPresetValues = new ArrayList<>();
 	protected ArrayList<String> fontPresetTitles = new ArrayList<>();
@@ -482,6 +494,7 @@ public class ConfigActivity extends BaseActivity implements View.OnClickListener
 	private void fillScreenSizePresets(int w, int h) {
 		ArrayList<String> screenPresets = this.screenPresets;
 		screenPresets.clear();
+		customPresets.clear();
 
 		screenPresets.add("128 x 128");
 		screenPresets.add("128 x 160");
@@ -505,6 +518,7 @@ public class ConfigActivity extends BaseActivity implements View.OnClickListener
 				.getStringSet("ResolutionsPreset", null);
 		if (preset != null) {
 			screenPresets.addAll(preset);
+			customPresets.addAll(preset);
 		}
 		Collections.sort(screenPresets, (o1, o2) -> {
 			int sep1 = o1.indexOf(" x ");
@@ -820,19 +834,131 @@ public class ConfigActivity extends BaseActivity implements View.OnClickListener
 	}
 
 	private void showScreenPresets(View v) {
-		PopupMenu popup = new PopupMenu(this, v);
+		presetsAdapter = new ResolutionAdapter();
+		presetsDialog = new AlertDialog.Builder(this)
+				.setTitle(R.string.SIZE_PRESETS)
+				.setAdapter(presetsAdapter, (d, which) -> {
+					String string = screenPresets.get(which);
+					int separator = string.indexOf(" x ");
+					binding.screenWidth.setText(string.substring(0, separator));
+					binding.screenHeight.setText(string.substring(separator + 3));
+				})
+				.setNegativeButton(android.R.string.cancel, null)
+				.create();
+		presetsDialog.setOnShowListener(d -> {
+			ListView listView = ((AlertDialog) d).getListView();
+			listView.setOnItemLongClickListener((parent, view, position, id) -> {
+				String item = screenPresets.get(position);
+				if (!customPresets.contains(item)) {
+					Toast.makeText(this, R.string.preset_cannot_delete, Toast.LENGTH_SHORT).show();
+				} else {
+					showPencilMenu(view, item);
+				}
+				return true;
+			});
+		});
+		presetsDialog.show();
+	}
+
+	private void showPencilMenu(View anchor, String preset) {
+		PopupMenu popup = new PopupMenu(this, anchor);
 		Menu menu = popup.getMenu();
-		for (String preset : screenPresets) {
-			menu.add(preset);
-		}
-		popup.setOnMenuItemClickListener(item -> {
-			String string = item.getTitle().toString();
-			int separator = string.indexOf(" x ");
-			binding.screenWidth.setText(string.substring(0, separator));
-			binding.screenHeight.setText(string.substring(separator + 3));
+		TypedValue tv = new TypedValue();
+		getTheme().resolveAttribute(android.R.attr.colorPrimary, tv, true);
+		SpannableString editLabel = new SpannableString(getString(R.string.edit));
+		editLabel.setSpan(new ForegroundColorSpan(tv.data), 0, editLabel.length(), 0);
+		menu.add(0, 0, 0, editLabel);
+		SpannableString deleteLabel = new SpannableString(getString(R.string.action_context_delete));
+		deleteLabel.setSpan(new ForegroundColorSpan(Color.RED), 0, deleteLabel.length(), 0);
+		menu.add(0, 1, 1, deleteLabel);
+		popup.setOnMenuItemClickListener(menuItem -> {
+			if (menuItem.getItemId() == 0) {
+				showEditResolutionDialog(preset);
+			} else {
+				if (presetsDialog != null) presetsDialog.dismiss();
+				new AlertDialog.Builder(this)
+						.setTitle(R.string.delete_resolution_title)
+						.setMessage(getString(R.string.delete_resolution_message, preset))
+						.setPositiveButton(R.string.action_context_delete, (d, w) -> deleteCustomPreset(preset))
+						.setNegativeButton(android.R.string.cancel, null)
+						.show();
+			}
 			return true;
 		});
 		popup.show();
+	}
+
+	private void showEditResolutionDialog(String preset) {
+		int sep = preset.indexOf(" x ");
+		String currentWidth = preset.substring(0, sep);
+		String currentHeight = preset.substring(sep + 3);
+		int padding = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 16,
+				getResources().getDisplayMetrics());
+		LinearLayout layout = new LinearLayout(this);
+		layout.setOrientation(LinearLayout.HORIZONTAL);
+		layout.setPadding(padding * 3, padding, padding * 3, padding);
+		layout.setGravity(Gravity.CENTER_VERTICAL);
+		EditText etWidth = new EditText(this);
+		etWidth.setInputType(InputType.TYPE_CLASS_NUMBER);
+		etWidth.setText(currentWidth);
+		etWidth.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1));
+		TextView xLabel = new TextView(this);
+		xLabel.setText(" x ");
+		EditText etHeight = new EditText(this);
+		etHeight.setInputType(InputType.TYPE_CLASS_NUMBER);
+		etHeight.setText(currentHeight);
+		etHeight.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1));
+		layout.addView(etWidth);
+		layout.addView(xLabel);
+		layout.addView(etHeight);
+		new AlertDialog.Builder(this)
+				.setTitle(R.string.edit_resolution_title)
+				.setView(layout)
+				.setPositiveButton(R.string.save, (d, w) -> {
+					int newW = parseInt(etWidth.getText().toString().trim());
+					int newH = parseInt(etHeight.getText().toString().trim());
+					if (newW <= 0 || newH <= 0) {
+						Toast.makeText(this, R.string.error, Toast.LENGTH_SHORT).show();
+						return;
+					}
+					String newPreset = newW + " x " + newH;
+					if (!newPreset.equals(preset)) {
+						updateCustomPreset(preset, newPreset);
+					}
+				})
+				.setNegativeButton(android.R.string.cancel, null)
+				.show();
+	}
+
+	private void updateCustomPreset(String oldPreset, String newPreset) {
+		if (screenPresets.contains(newPreset)) {
+			Toast.makeText(this, R.string.not_saved_exists, Toast.LENGTH_SHORT).show();
+			return;
+		}
+		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+		Set<String> saved = preferences.getStringSet("ResolutionsPreset", null);
+		Set<String> updated = saved != null ? new HashSet<>(saved) : new HashSet<>();
+		updated.remove(oldPreset);
+		updated.add(newPreset);
+		preferences.edit().putStringSet("ResolutionsPreset", updated).apply();
+		customPresets.remove(oldPreset);
+		screenPresets.remove(oldPreset);
+		customPresets.add(newPreset);
+		screenPresets.add(newPreset);
+		if (presetsAdapter != null) presetsAdapter.notifyDataSetChanged();
+	}
+
+	private void deleteCustomPreset(String preset) {
+		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+		Set<String> saved = preferences.getStringSet("ResolutionsPreset", null);
+		if (saved != null) {
+			Set<String> updated = new HashSet<>(saved);
+			updated.remove(preset);
+			preferences.edit().putStringSet("ResolutionsPreset", updated).apply();
+		}
+		customPresets.remove(preset);
+		screenPresets.remove(preset);
+		if (presetsAdapter != null) presetsAdapter.notifyDataSetChanged();
 	}
 
 	private void showColorPicker(EditText et) {
@@ -877,6 +1003,7 @@ public class ConfigActivity extends BaseActivity implements View.OnClickListener
 		if (set.add(preset)) {
 			preferences.edit().putStringSet("ResolutionsPreset", set).apply();
 			screenPresets.add(preset);
+			customPresets.add(preset);
 			Toast.makeText(this, R.string.saved, Toast.LENGTH_SHORT).show();
 		} else {
 			Toast.makeText(this, R.string.not_saved_exists, Toast.LENGTH_SHORT).show();
@@ -886,6 +1013,31 @@ public class ConfigActivity extends BaseActivity implements View.OnClickListener
 	@Override
 	public void onTuneComplete(float[] values) {
 		params.shader.values = values;
+	}
+
+	private class ResolutionAdapter extends ArrayAdapter<String> {
+		ResolutionAdapter() {
+			super(ConfigActivity.this, R.layout.item_resolution_preset, screenPresets);
+		}
+
+		@NonNull
+		@Override
+		public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+			if (convertView == null) {
+				convertView = getLayoutInflater().inflate(R.layout.item_resolution_preset, parent, false);
+			}
+			String item = getItem(position);
+			((TextView) convertView.findViewById(R.id.resolution_text)).setText(item);
+			View icon = convertView.findViewById(R.id.custom_icon);
+			if (customPresets.contains(item)) {
+				icon.setVisibility(View.VISIBLE);
+				icon.setOnClickListener(clickedView -> showPencilMenu(clickedView, item));
+			} else {
+				icon.setVisibility(View.GONE);
+				icon.setOnClickListener(null);
+			}
+			return convertView;
+		}
 	}
 
 	private static class ColorTextWatcher implements TextWatcher {

--- a/app/src/main/res/drawable/ic_edit_custom.xml
+++ b/app/src/main/res/drawable/ic_edit_custom.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="18dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z" />
+</vector>

--- a/app/src/main/res/layout/item_resolution_preset.xml
+++ b/app/src/main/res/layout/item_resolution_preset.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="48dp"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingEnd="16dp"
+    android:paddingStart="16dp">
+
+    <TextView
+        android:id="@+id/resolution_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+    <ImageView
+        android:id="@+id/custom_icon"
+        android:layout_width="18dp"
+        android:layout_height="18dp"
+        android:contentDescription="@null"
+        android:src="@drawable/ic_edit_custom"
+        android:tint="?attr/colorControlNormal"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_resolution_preset.xml
+++ b/app/src/main/res/layout/item_resolution_preset.xml
@@ -20,7 +20,7 @@
         android:layout_height="18dp"
         android:contentDescription="@null"
         android:src="@drawable/ic_edit_custom"
-        android:tint="?attr/colorControlNormal"
+        android:tint="@color/btn_bg_normal"
         android:visibility="gone" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,5 +257,9 @@
     <string name="error_name_exists">Already exists, enter other name</string>
     <string name="default_label">"%s (default)"</string>
     <string name="not_saved_exists">Already exists</string>
+    <string name="preset_cannot_delete">Cannot delete a preset resolution</string>
+    <string name="delete_resolution_title">Delete resolution?</string>
+    <string name="delete_resolution_message">Delete %s?</string>
+    <string name="edit_resolution_title">Edit resolution</string>
     <string name="alert_rewrite_profile">A profile named \"%1$s\" already exists.\nDo you want to overwrite it?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,7 +257,7 @@
     <string name="error_name_exists">Already exists, enter other name</string>
     <string name="default_label">"%s (default)"</string>
     <string name="not_saved_exists">Already exists</string>
-    <string name="preset_cannot_delete">Cannot delete a preset resolution</string>
+    <string name="preset_cannot_delete">Cannot edit built-in presets</string>
     <string name="delete_resolution_title">Delete resolution?</string>
     <string name="delete_resolution_message">Delete %s?</string>
     <string name="edit_resolution_title">Edit resolution</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -12,7 +12,12 @@
         <item name="bg_config_card">@drawable/bg_config_card</item>
         <item name="textColorPrimary">@color/text_primary</item>
         <item name="textColorSecondary">@color/text_secondary</item>
+        <item name="alertDialogTheme">@style/AppAlertDialogTheme</item>
         <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
+    </style>
+
+    <style name="AppAlertDialogTheme" parent="Theme.AppCompat.DayNight.Dialog.Alert">
+        <item name="colorAccent">@color/btn_bg_normal</item>
     </style>
 
     <style name="AppTheme.NoActionBar">


### PR DESCRIPTION
Fixes #1105 — there was no way to remove or correct a custom resolution once added.

**What this does:**
- The preset list now uses a custom adapter with a pencil icon on user-added entries
- Tapping the pencil (or long-pressing a custom row) shows an Edit / Delete dropdown
- Edit opens a pre-filled dialog; Delete asks for confirmation
- Built-in presets show a toast if long-pressed: "Cannot edit built-in presets"
- Custom presets persist correctly across navigation and re-sort into position after every change

**Files changed:**
- `ConfigActivity.java` — main logic
- `ic_edit_custom.xml` — pencil icon drawable
- `item_resolution_preset.xml` — list row layout
- `strings.xml` — 4 new strings
- `styles.xml` — `AppAlertDialogTheme` scoped to dialogs only so other widgets are unaffected

---

*Transparency note: This was implemented with AI assistance (Claude Code). I directed the feature, tested it on my Redmi 15, and the entire workflow was done from my phone — no PC involved. I'll explain that setup in more detail in the future. Meanwhile, if you'd rather not merge AI-assisted contributions, that's completely fine with me — I just wanted to be upfront about it.*